### PR TITLE
ci: add a matrix to test on many Node versions

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -5,10 +5,17 @@ on: [pull_request, push, workflow_dispatch]
 jobs:
   test:
     name: Test
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci
       - name: Check types


### PR DESCRIPTION
Add a matrix called `node-version` with 3 Node version to use in the tests.